### PR TITLE
Update proxy content-length tests

### DIFF
--- a/pkg/registry/generic/rest/proxy.go
+++ b/pkg/registry/generic/rest/proxy.go
@@ -114,6 +114,7 @@ func (h *UpgradeAwareProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 		return
 	}
 	newReq.Header = req.Header
+	newReq.ContentLength = req.ContentLength
 
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
 	proxy.Transport = h.Transport


### PR DESCRIPTION
This uses raw connection reads/writes to actually test various transfer-encodings without letting the http package manipulate request headers
